### PR TITLE
Override minted bgcolor to prevent that user set global background color by \setminted

### DIFF
--- a/source/termsim.dtx
+++ b/source/termsim.dtx
@@ -1218,6 +1218,7 @@ Copyright and Licence
         baselinestretch=\fp_eval:n { \l_@@_shell_baseline_stretch_fp },%
         breaksymbolleft={},%
         linenos=false,%
+        bgcolor={},%
       },%
       minted~language=bash%
     }


### PR DESCRIPTION
The terminal will show a background if user set a global bgcolor for minted, eg.

```latex
\definecolor{code-bg-color}{rgb}{0.95,0.95,0.95}
\setminted{
   breaklines,
   linenos,
   rulecolor=gray,
   framerule=0.5pt,
   bgcolor=code-bg-color,
   fontsize=\small
}
```
This will looks as below:
![image](https://user-images.githubusercontent.com/6427851/197230053-ea91d8ba-beb3-4293-be48-cd2afd9ae413.png)

This pull request fixes this case, so that the terminal displays as expected even when a background is set in minted. Here is a screenshot which uses both minted and termsim:

![image](https://user-images.githubusercontent.com/6427851/197231798-bc8e7217-9465-4ec6-b48c-551832e5772c.png)
