### PR TITLE
Fix Option `shstretch` Typo.

### DIFF
--- a/source/termsim.dtx
+++ b/source/termsim.dtx
@@ -1162,10 +1162,10 @@ Copyright and Licence
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{shstrech}
+% \begin{macro}{shstretch}
 % 基线伸展系数
 %    \begin{macrocode}
-    shstretch .fp_set:N  = \l_@@_shell_baseline_strech_fp,
+    shstretch .fp_set:N  = \l_@@_shell_baseline_stretch_fp,
     shstretch .initial:n = 1.0,
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
This changes `\l_@@_shell_baseline_strech_fp` to `\l_@@_shell_baseline_stretch_fp`.

Originally, `shstretch` does not make any difference.
This is a **breaking** change, as the original effective `baselinestretch` for `minted` is 0 not 1.0.